### PR TITLE
Fix Transparency for Gtk4 DING

### DIFF
--- a/theming.js
+++ b/theming.js
@@ -468,7 +468,7 @@ var Transparency = class DashToDock_Transparency {
             return metaWindow.get_monitor() === dash._monitorIndex &&
                    metaWindow.showing_on_its_workspace() &&
                    metaWindow.get_window_type() !== Meta.WindowType.DESKTOP &&
-                   (!Meta.is_wayland_compositor() || !metaWindow.skip_taskbar);
+                   !metaWindow.skip_taskbar;
         });
 
         /* Check if at least one window is near enough to the panel.


### PR DESCRIPTION
In Gtk4-DING, the Gtk4 fork of DING, even X11 windows are handled like wayland windows. They are therefore not detected by type DESKTOP, and need to be detected by skip taskbar hint to enable correct transparency of the dock on X11 with that extension.

This should work with MR #1879, which is for fixing intellihide with Gtk4-DING